### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,6 @@ fn container_sim() {
     for iteration in 1..=10 {
         container.evaporate_condensate();
         container.convect(Time::new::<second>(0.1));
-        println!("Iteration {iteration:2.}: {container}");
+        println!("Iteration {iteration:2}: {container}");
     }
 }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.